### PR TITLE
Implement save button functionality from index.tsc

### DIFF
--- a/src/features/editor/TextEditor.tsx
+++ b/src/features/editor/TextEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { LoadingOverlay } from "@mantine/core";
 import styled from "styled-components";
+import toast from "react-hot-toast";
 import Editor, { type EditorProps, loader, type OnMount, useMonaco } from "@monaco-editor/react";
 import useConfig from "../../store/useConfig";
 import useFile from "../../store/useFile";
@@ -28,6 +29,8 @@ const TextEditor = () => {
   const setError = useFile(state => state.setError);
   const jsonSchema = useFile(state => state.jsonSchema);
   const getHasChanges = useFile(state => state.getHasChanges);
+  const setHasChanges = useFile(state => state.setHasChanges);
+  const getContents = useFile(state => state.getContents);
   const theme = useConfig(state => (state.darkmodeEnabled ? "vs-dark" : "light"));
   const fileType = useFile(state => state.format);
 
@@ -59,18 +62,47 @@ const TextEditor = () => {
       }
     };
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        handleSave();
+      }
+    };
+
     window.addEventListener("beforeunload", beforeunload);
+    window.addEventListener("keydown", handleKeyDown);
 
     return () => {
       window.removeEventListener("beforeunload", beforeunload);
+      window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [getHasChanges]);
+  }, [getHasChanges, handleSave]);
+
+  const handleSave = useCallback(() => {
+    try {
+      const currentContents = getContents();
+      localStorage.setItem('jsoncrack_saved_content', currentContents);
+      localStorage.setItem('jsoncrack_saved_format', fileType);
+      localStorage.setItem('jsoncrack_saved_timestamp', new Date().toISOString());
+      
+      setHasChanges(false);
+      toast.success('Content saved successfully!');
+    } catch (error) {
+      toast.error('Failed to save content');
+      console.error('Save error:', error);
+    }
+  }, [getContents, fileType, setHasChanges]);
 
   const handleMount: OnMount = useCallback(editor => {
     editor.onDidPaste(() => {
       editor.getAction("editor.action.formatDocument")?.run();
     });
-  }, []);
+
+    // Add Ctrl+S keyboard shortcut
+    editor.addCommand(monaco?.KeyMod.CtrlCmd | monaco?.KeyCode.KeyS, () => {
+      handleSave();
+    });
+  }, [monaco?.KeyMod, monaco?.KeyCode, handleSave]);
 
   return (
     <StyledEditorWrapper>

--- a/src/features/editor/Toolbar/FileMenu.tsx
+++ b/src/features/editor/Toolbar/FileMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Flex, Menu } from "@mantine/core";
 import { event as gaEvent } from "nextjs-google-analytics";
+import toast from "react-hot-toast";
 import { CgChevronDown } from "react-icons/cg";
 import useFile from "../../../store/useFile";
 import { useModal } from "../../../store/useModal";
@@ -10,6 +11,8 @@ export const FileMenu = () => {
   const setVisible = useModal(state => state.setVisible);
   const getContents = useFile(state => state.getContents);
   const getFormat = useFile(state => state.getFormat);
+  const setContents = useFile(state => state.setContents);
+  const setFormat = useFile(state => state.setFormat);
 
   const handleSave = () => {
     const a = document.createElement("a");
@@ -21,6 +24,24 @@ export const FileMenu = () => {
 
     gaEvent("save_file", { label: getFormat() });
   };
+
+  const handleLoadSaved = () => {
+    const savedContent = localStorage.getItem("jsoncrack_saved_content");
+    const savedFormat = localStorage.getItem("jsoncrack_saved_format");
+    
+    if (savedContent) {
+      setContents({ contents: savedContent, hasChanges: false });
+      if (savedFormat) {
+        setFormat(savedFormat as any);
+      }
+      toast.success("Saved content loaded successfully!");
+      gaEvent("load_saved_content");
+    } else {
+      toast.error("No saved content found");
+    }
+  };
+
+  const hasSavedContent = localStorage.getItem("jsoncrack_saved_content") !== null;
 
   return (
     <Menu shadow="md" withArrow>
@@ -36,6 +57,11 @@ export const FileMenu = () => {
         <Menu.Item fz={12} onClick={() => setVisible("ImportModal", true)}>
           Import
         </Menu.Item>
+        {hasSavedContent && (
+          <Menu.Item fz={12} onClick={handleLoadSaved}>
+            Load Saved
+          </Menu.Item>
+        )}
         <Menu.Item fz={12} onClick={handleSave}>
           Export
         </Menu.Item>

--- a/src/features/editor/Toolbar/index.tsx
+++ b/src/features/editor/Toolbar/index.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import toast from "react-hot-toast";
 import { AiOutlineFullscreen } from "react-icons/ai";
 import { FaFireFlameCurved, FaGithub } from "react-icons/fa6";
+import { MdSave } from "react-icons/md";
 import { type FileFormat, formats } from "../../../enums/file.enum";
 import { JSONCrackLogo } from "../../../layout/JsonCrackLogo";
 import useFile from "../../../store/useFile";
@@ -45,6 +46,27 @@ function fullscreenBrowser() {
 export const Toolbar = () => {
   const setFormat = useFile(state => state.setFormat);
   const format = useFile(state => state.format);
+  const getContents = useFile(state => state.getContents);
+  const setHasChanges = useFile(state => state.setHasChanges);
+  const hasChanges = useFile(state => state.hasChanges);
+
+  const handleSave = () => {
+    try {
+      // Save to localStorage for persistence
+      const contents = getContents();
+      localStorage.setItem('jsoncrack_saved_content', contents);
+      localStorage.setItem('jsoncrack_saved_format', format);
+      localStorage.setItem('jsoncrack_saved_timestamp', new Date().toISOString());
+      
+      // Mark as saved (no changes)
+      setHasChanges(false);
+      
+      toast.success('Content saved successfully!');
+    } catch (error) {
+      toast.error('Failed to save content');
+      console.error('Save error:', error);
+    }
+  };
 
   return (
     <StyledTools>
@@ -68,6 +90,17 @@ export const Toolbar = () => {
         <FileMenu />
         <ViewMenu />
         <ToolsMenu />
+        <Button
+          onClick={handleSave}
+          size="compact-sm"
+          variant={hasChanges ? "filled" : "outline"}
+          color={hasChanges ? "blue" : "gray"}
+          leftSection={<MdSave size="14" />}
+          fz="12"
+          fw="500"
+        >
+          Save
+        </Button>
       </Group>
       <Group gap="xs" justify="right" w="100%" style={{ flexWrap: "nowrap" }}>
         <Button

--- a/src/store/useFile.ts
+++ b/src/store/useFile.ts
@@ -167,9 +167,22 @@ const useFile = create<FileStates & JsonActions>()((set, get) => ({
     }
 
     let contents = defaultJson;
-    const sessionContent = sessionStorage.getItem("content") as string | null;
-    const format = sessionStorage.getItem("format") as FileFormat | null;
-    if (sessionContent && !widget) contents = sessionContent;
+    let format: FileFormat | null = null;
+    
+    // First check for saved content in localStorage
+    const savedContent = localStorage.getItem("jsoncrack_saved_content");
+    const savedFormat = localStorage.getItem("jsoncrack_saved_format") as FileFormat | null;
+    
+    if (savedContent && !widget) {
+      contents = savedContent;
+      format = savedFormat;
+    } else {
+      // Fall back to session content
+      const sessionContent = sessionStorage.getItem("content") as string | null;
+      const sessionFormat = sessionStorage.getItem("format") as FileFormat | null;
+      if (sessionContent && !widget) contents = sessionContent;
+      if (sessionFormat) format = sessionFormat;
+    }
 
     if (format) set({ format });
     get().setContents({ contents, hasChanges: false });


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add persistent save functionality to the editor, including a save button, keyboard shortcut, and load option.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the "save" option only exported the file. This change introduces actual data persistence using localStorage, allowing users to resume their work across browser sessions.

---

[Open in Web](https://cursor.com/agents?id=bc-f26c1332-d68b-4779-959f-48662fd28c0e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f26c1332-d68b-4779-959f-48662fd28c0e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)